### PR TITLE
Interactive WebGL hero, 3D work cards, and mobile menu fix

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -277,6 +277,16 @@ body.is-loading { overflow: hidden; }
   border-bottom-color: var(--line);
 }
 .header.is-hidden { transform: translateY(-100%); }
+/* While the mobile menu is open the header must not establish a containing
+   block for the fixed full-screen overlay — transform AND backdrop-filter
+   both do, so neutralise both (the open menu has its own opaque background). */
+.header.menu-open {
+  transform: none !important;
+  -webkit-backdrop-filter: none !important;
+  backdrop-filter: none !important;
+  background: transparent !important;
+  transition: none;
+}
 
 .nav {
   height: var(--header-h);
@@ -722,8 +732,27 @@ body.is-ready .anim-rise { animation: rise 1.05s var(--ease-out) var(--d, 0s) fo
   border: 1px solid var(--line);
   background: var(--surface);
   padding: clamp(28px, 3vw, 44px);
-  transition: border-color 0.4s ease, transform 0.4s var(--ease-out);
+  /* --cry/--cz come from the scroll coverflow, --mrx/--mry from pointer tilt */
+  transform:
+    perspective(1500px)
+    translateZ(var(--cz, 0px))
+    rotateY(calc(var(--cry, 0deg) + var(--mry, 0deg)))
+    rotateX(var(--mrx, 0deg));
+  opacity: calc(0.5 + 0.5 * var(--cflat, 1));
+  transition: border-color 0.4s ease, opacity 0.5s var(--ease-out);
 }
+/* cursor-tracked sheen, revealed only while tilting */
+.work-card::after {
+  content: "";
+  position: absolute; inset: 0;
+  background: radial-gradient(460px circle at var(--gx, 50%) var(--gy, 50%),
+    color-mix(in srgb, var(--accent) 16%, transparent), transparent 58%);
+  opacity: 0;
+  transition: opacity 0.45s ease;
+  pointer-events: none;
+  z-index: 2;
+}
+.work-card.is-tilting::after { opacity: 1; }
 .work-card:hover { border-color: var(--line-strong); }
 .work-card.is-flagship { width: clamp(480px, 52vw, 760px); }
 
@@ -809,6 +838,8 @@ body.is-ready .anim-rise { animation: rise 1.05s var(--ease-out) var(--d, 0s) fo
     padding-inline: var(--gutter);
   }
   .works-intro, .work-card, .work-card.is-flagship { width: 100%; }
+  .work-card { transform: none !important; opacity: 1 !important; }
+  .work-card::after { display: none; }
   .works-count { display: none; }
 }
 

--- a/assets/js/hero3d.js
+++ b/assets/js/hero3d.js
@@ -1,0 +1,290 @@
+/* ============================================================
+   AlpovkApps — WebGL hero
+   A reactive point-field rendered with three.js. A fine grid of
+   monochrome points rests with a faint ambient drift; the cursor
+   stirs a champagne ripple-pool that radiates waves and brightens
+   the points it passes. Calm when idle, alive on movement.
+   Theme-aware, paused off-screen, degrades to a static frame for
+   reduced-motion, and no-ops cleanly without WebGL.
+   ============================================================ */
+import * as THREE from "three";
+
+const canvas = document.getElementById("heroCanvas");
+const hero = canvas && canvas.parentElement;
+const reduceMotion = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+
+/* Quick WebGL capability probe so we never throw on old/blocked GPUs. */
+function webglOK() {
+  try {
+    const c = document.createElement("canvas");
+    return !!(window.WebGLRenderingContext && (c.getContext("webgl") || c.getContext("experimental-webgl")));
+  } catch (e) {
+    return false;
+  }
+}
+
+function readColors() {
+  const cs = getComputedStyle(document.documentElement);
+  const base = new THREE.Color((cs.getPropertyValue("--fg") || "#eceae4").trim());
+  const accent = new THREE.Color((cs.getPropertyValue("--accent") || "#c8ad7e").trim());
+  return { base, accent };
+}
+
+/* A flat grid of points spanning generous world extents so it covers
+   the viewport at our camera distance across aspect ratios. */
+const EXT_X = 4.2;
+const EXT_Y = 2.6;
+function buildGrid(cols, rows) {
+  const positions = new Float32Array(cols * rows * 3);
+  let i = 0;
+  for (let r = 0; r < rows; r++) {
+    for (let c = 0; c < cols; c++) {
+      positions[i++] = (c / (cols - 1) - 0.5) * 2 * EXT_X;
+      positions[i++] = (r / (rows - 1) - 0.5) * 2 * EXT_Y;
+      positions[i++] = 0;
+    }
+  }
+  return positions;
+}
+
+const VERT = /* glsl */ `
+  uniform float uTime;
+  uniform float uPixelRatio;
+  uniform vec2  uMouse;
+  uniform float uStrength;
+  varying float vGlow;
+
+  // Simplex 3D noise (Ashima / Stefan Gustavson)
+  vec4 permute(vec4 x){ return mod(((x*34.0)+1.0)*x, 289.0); }
+  vec4 taylorInvSqrt(vec4 r){ return 1.79284291400159 - 0.85373472095314 * r; }
+  float snoise(vec3 v){
+    const vec2 C = vec2(1.0/6.0, 1.0/3.0);
+    const vec4 D = vec4(0.0, 0.5, 1.0, 2.0);
+    vec3 i  = floor(v + dot(v, C.yyy));
+    vec3 x0 = v - i + dot(i, C.xxx);
+    vec3 g = step(x0.yzx, x0.xyz);
+    vec3 l = 1.0 - g;
+    vec3 i1 = min(g.xyz, l.zxy);
+    vec3 i2 = max(g.xyz, l.zxy);
+    vec3 x1 = x0 - i1 + 1.0 * C.xxx;
+    vec3 x2 = x0 - i2 + 2.0 * C.xxx;
+    vec3 x3 = x0 - 1.0 + 3.0 * C.xxx;
+    i = mod(i, 289.0);
+    vec4 p = permute(permute(permute(
+              i.z + vec4(0.0, i1.z, i2.z, 1.0))
+            + i.y + vec4(0.0, i1.y, i2.y, 1.0))
+            + i.x + vec4(0.0, i1.x, i2.x, 1.0));
+    float n_ = 1.0/7.0;
+    vec3 ns = n_ * D.wyz - D.xzx;
+    vec4 j = p - 49.0 * floor(p * ns.z * ns.z);
+    vec4 x_ = floor(j * ns.z);
+    vec4 y_ = floor(j - 7.0 * x_);
+    vec4 x = x_ * ns.x + ns.yyyy;
+    vec4 y = y_ * ns.x + ns.yyyy;
+    vec4 h = 1.0 - abs(x) - abs(y);
+    vec4 b0 = vec4(x.xy, y.xy);
+    vec4 b1 = vec4(x.zw, y.zw);
+    vec4 s0 = floor(b0) * 2.0 + 1.0;
+    vec4 s1 = floor(b1) * 2.0 + 1.0;
+    vec4 sh = -step(h, vec4(0.0));
+    vec4 a0 = b0.xzyw + s0.xzyw * sh.xxyy;
+    vec4 a1 = b1.xzyw + s1.xzyw * sh.zzww;
+    vec3 p0 = vec3(a0.xy, h.x);
+    vec3 p1 = vec3(a0.zw, h.y);
+    vec3 p2 = vec3(a1.xy, h.z);
+    vec3 p3 = vec3(a1.zw, h.w);
+    vec4 norm = taylorInvSqrt(vec4(dot(p0,p0), dot(p1,p1), dot(p2,p2), dot(p3,p3)));
+    p0 *= norm.x; p1 *= norm.y; p2 *= norm.z; p3 *= norm.w;
+    vec4 m = max(0.6 - vec4(dot(x0,x0), dot(x1,x1), dot(x2,x2), dot(x3,x3)), 0.0);
+    m = m * m;
+    return 42.0 * dot(m*m, vec4(dot(p0,x0), dot(p1,x1), dot(p2,x2), dot(p3,x3)));
+  }
+
+  void main() {
+    vec3 pos = position;
+
+    // gentle ambient breathing so the grid is never dead-flat
+    float ambient = snoise(vec3(pos.xy * 0.34, uTime * 0.08)) * 0.10;
+
+    // cursor ripple-pool: wave radiating from the pointer, falling off with distance
+    float dist  = distance(pos.xy, uMouse);
+    float fall  = exp(-dist * 0.85);
+    float wave  = sin(dist * 3.4 - uTime * 2.6) * exp(-dist * 0.5);
+    float pool  = (fall * 0.45 + wave * 0.22) * uStrength;
+
+    pos.z = ambient + pool;
+    vGlow = clamp(fall * uStrength * 1.25 + abs(wave) * 0.18 * uStrength + pos.z * 0.15, 0.0, 1.0);
+
+    vec4 mv = modelViewMatrix * vec4(pos, 1.0);
+    gl_Position = projectionMatrix * mv;
+    // small at rest, swelling where the cursor pool brightens them
+    gl_PointSize = (1.8 + vGlow * 5.0) * uPixelRatio;
+  }
+`;
+
+const FRAG = /* glsl */ `
+  precision mediump float;
+  uniform vec3 uColorBase;
+  uniform vec3 uColorAccent;
+  varying float vGlow;
+
+  void main() {
+    vec2 c = gl_PointCoord - 0.5;
+    float d = length(c);
+    if (d > 0.5) discard;
+    float soft = smoothstep(0.5, 0.08, d);
+    vec3 col = mix(uColorBase, uColorAccent, vGlow);
+    float alpha = soft * (0.16 + vGlow * 0.72);
+    gl_FragColor = vec4(col, alpha);
+  }
+`;
+
+let uniforms;
+
+function init() {
+  const renderer = new THREE.WebGLRenderer({
+    canvas,
+    alpha: true,
+    antialias: true,
+    powerPreference: "high-performance",
+  });
+  renderer.setClearAlpha(0);
+
+  const dpr = Math.min(window.devicePixelRatio || 1, 2);
+
+  const scene = new THREE.Scene();
+  const camera = new THREE.PerspectiveCamera(45, 1, 0.1, 100);
+  camera.position.set(0, 0, 4);
+
+  const geometry = new THREE.BufferGeometry();
+  geometry.setAttribute("position", new THREE.BufferAttribute(buildGrid(150, 92), 3));
+
+  const { base, accent } = readColors();
+  uniforms = {
+    uTime: { value: 0 },
+    uPixelRatio: { value: dpr },
+    uMouse: { value: new THREE.Vector2(999, 999) }, // offscreen until the pointer moves
+    uStrength: { value: 0 },
+    uColorBase: { value: base },
+    uColorAccent: { value: accent },
+  };
+
+  const material = new THREE.ShaderMaterial({
+    uniforms,
+    vertexShader: VERT,
+    fragmentShader: FRAG,
+    transparent: true,
+    depthWrite: false,
+    blending: THREE.NormalBlending,
+  });
+
+  const points = new THREE.Points(geometry, material);
+  scene.add(points);
+
+  /* ---- mouse → world-plane mapping ---- */
+  // half-extents of the z=0 plane visible at the camera distance
+  let halfH = 1, halfW = 1;
+  const ndc = { x: 0, y: 0, has: false };
+
+  function resize() {
+    const w = hero.clientWidth || window.innerWidth;
+    const h = hero.clientHeight || window.innerHeight;
+    renderer.setPixelRatio(dpr);
+    renderer.setSize(w, h, false);
+    camera.aspect = w / h;
+    camera.position.z = w < 700 ? 5.2 : 4;
+    camera.updateProjectionMatrix();
+    halfH = Math.tan((camera.fov * Math.PI) / 360) * camera.position.z;
+    halfW = halfH * camera.aspect;
+  }
+  resize();
+  // immediate first frame so the canvas is never blank before the loop starts
+  renderer.render(scene, camera);
+
+  /* ---- pointer reactivity ---- */
+  let strengthTarget = 0;
+  if (!reduceMotion && window.matchMedia("(pointer: fine)").matches) {
+    window.addEventListener("pointermove", (e) => {
+      ndc.x = (e.clientX / window.innerWidth) * 2 - 1;
+      ndc.y = -((e.clientY / window.innerHeight) * 2 - 1);
+      ndc.has = true;
+      strengthTarget = 1;           // stir the pool while moving
+    }, { passive: true });
+    window.addEventListener("pointerleave", () => { strengthTarget = 0; }, { passive: true });
+  }
+
+  /* ---- theme awareness ---- */
+  const themeObserver = new MutationObserver(() => {
+    const c = readColors();
+    uniforms.uColorBase.value.copy(c.base);
+    uniforms.uColorAccent.value.copy(c.accent);
+    if (!running) renderer.render(scene, camera);
+  });
+  themeObserver.observe(document.documentElement, { attributes: true, attributeFilter: ["data-theme"] });
+
+  /* ---- run / pause lifecycle ---- */
+  let running = false;
+  let rafId = 0;
+  const clock = new THREE.Clock();
+  const mouseWorld = uniforms.uMouse.value;
+  const targetWorld = new THREE.Vector2(999, 999);
+
+  function frame() {
+    if (!running) return;
+    rafId = requestAnimationFrame(frame);
+    uniforms.uTime.value = clock.getElapsedTime();
+
+    if (ndc.has) {
+      targetWorld.set(ndc.x * halfW, ndc.y * halfH);
+      mouseWorld.lerp(targetWorld, 0.12);  // trailing pursuit of the cursor
+    }
+    // strength rises fast on movement, eases back toward a calm idle drift
+    const idle = 0.18;
+    uniforms.uStrength.value += ((strengthTarget ? 1 : idle) - uniforms.uStrength.value) * 0.04;
+    strengthTarget = 0; // require continuous movement to stay fully energised
+
+    renderer.render(scene, camera);
+  }
+
+  function start() {
+    if (running || reduceMotion) return;
+    running = true;
+    clock.getElapsedTime();
+    frame();
+  }
+  function stop() {
+    running = false;
+    cancelAnimationFrame(rafId);
+  }
+
+  if (reduceMotion) {
+    uniforms.uTime.value = 0.4;
+    uniforms.uStrength.value = 0.18;
+    renderer.render(scene, camera);
+  } else {
+    const io = new IntersectionObserver(([en]) => {
+      if (en.isIntersecting && !document.hidden) start();
+      else stop();
+    }, { threshold: 0 });
+    io.observe(hero);
+
+    document.addEventListener("visibilitychange", () => {
+      if (document.hidden) stop();
+      else if (hero.getBoundingClientRect().bottom > 0) start();
+    });
+  }
+
+  let resizeTimer;
+  window.addEventListener("resize", () => {
+    clearTimeout(resizeTimer);
+    resizeTimer = setTimeout(() => {
+      resize();
+      if (!running) renderer.render(scene, camera);
+    }, 180);
+  }, { passive: true });
+}
+
+// Kick off only after VERT/FRAG and all helpers above are initialised.
+if (canvas && hero && webglOK()) {
+  init();
+}

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -30,7 +30,7 @@
   themeToggle.addEventListener("click", () => {
     const next = doc.dataset.theme === "dark" ? "light" : "dark";
     localStorage.setItem(THEME_KEY, next);
-    const swap = () => { applyTheme(next); refreshDustColor(); };
+    const swap = () => { applyTheme(next); };
 
     if (document.startViewTransition && !reduceMotion) {
       const rect = themeToggle.getBoundingClientRect();
@@ -132,12 +132,18 @@
   const closeMenu = () => {
     burger.classList.remove("is-open");
     navLinks.classList.remove("is-open");
+    header.classList.remove("menu-open");
     burger.setAttribute("aria-expanded", "false");
     body.style.overflow = "";
   };
 
   burger.addEventListener("click", () => {
     const open = !navLinks.classList.contains("is-open");
+    // The header is position:fixed and gets transformed on scroll (is-hidden).
+    // A transformed ancestor becomes the containing block for the fixed
+    // overlay, mispositioning it on lower sections — so neutralise it here.
+    if (open) header.classList.remove("is-hidden");
+    header.classList.toggle("menu-open", open);
     burger.classList.toggle("is-open", open);
     navLinks.classList.toggle("is-open", open);
     burger.setAttribute("aria-expanded", String(open));
@@ -311,6 +317,7 @@
   const worksIdx = document.getElementById("worksIdx");
   const worksBar = document.getElementById("worksBar");
   const workCardCount = 6;
+  const coverCards = worksTrack ? [...worksTrack.querySelectorAll(".work-card")] : [];
   let worksTop = 0;
   let worksMaxX = 0;
 
@@ -403,6 +410,16 @@
         worksIdx.textContent = String(1 + Math.round(p * (workCardCount - 1))).padStart(2, "0");
       }
       if (worksBar) worksBar.style.transform = `scaleX(${p})`;
+
+      // coverflow: cards swing in 3D and recede as they leave centre
+      const vcx = window.innerWidth / 2;
+      for (const card of coverCards) {
+        const r = card.getBoundingClientRect();
+        const off = clamp((r.left + r.width / 2 - vcx) / window.innerWidth, -1, 1);
+        card.style.setProperty("--cry", `${(-off * 24).toFixed(2)}deg`);
+        card.style.setProperty("--cz", `${(-Math.abs(off) * 260).toFixed(1)}px`);
+        card.style.setProperty("--cflat", (1 - Math.min(Math.abs(off) * 1.6, 0.7)).toFixed(3));
+      }
     }
 
     // big marquee: constant drift + scroll-velocity skew
@@ -471,83 +488,7 @@
     cursorLoop();
   }
 
-  /* ---------------- Dust canvas (hero) ---------------- */
-  const canvas = document.getElementById("heroCanvas");
-  let dustRGB = "200, 173, 126";
-
-  function refreshDustColor() {
-    dustRGB = getComputedStyle(doc).getPropertyValue("--dust").trim() || dustRGB;
-  }
-
-  if (canvas && !reduceMotion) {
-    const ctx = canvas.getContext("2d");
-    const dpr = Math.min(window.devicePixelRatio || 1, 2);
-    let specks = [];
-    let width = 0, height = 0;
-    let running = true;
-    let t = 0;
-
-    refreshDustColor();
-
-    const build = () => {
-      const rect = canvas.parentElement.getBoundingClientRect();
-      width = rect.width;
-      height = rect.height;
-      canvas.width = width * dpr;
-      canvas.height = height * dpr;
-      ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
-      const count = clamp(Math.floor((width * height) / 26000), 18, 60);
-      specks = Array.from({ length: count }, () => ({
-        x: Math.random() * width,
-        y: Math.random() * height,
-        r: Math.random() * 1.4 + 0.4,
-        vx: -(Math.random() * 0.14 + 0.03),
-        vy: -(Math.random() * 0.1 + 0.02),
-        ph: Math.random() * Math.PI * 2,
-        sp: Math.random() * 0.014 + 0.006,
-      }));
-    };
-
-    const frame = () => {
-      if (!running) return;
-      t += 1;
-      ctx.clearRect(0, 0, width, height);
-      for (const s of specks) {
-        s.x += s.vx;
-        s.y += s.vy;
-        if (s.x < -8) s.x = width + 8;
-        if (s.y < -8) s.y = height + 8;
-        const a = 0.1 + 0.26 * (0.5 + 0.5 * Math.sin(s.ph + t * s.sp));
-        ctx.beginPath();
-        ctx.arc(s.x, s.y, s.r, 0, Math.PI * 2);
-        ctx.fillStyle = `rgba(${dustRGB}, ${a.toFixed(3)})`;
-        ctx.fill();
-      }
-      requestAnimationFrame(frame);
-    };
-
-    const visObserver = new IntersectionObserver(([en]) => {
-      const shouldRun = en.isIntersecting && !document.hidden;
-      if (shouldRun && !running) { running = true; frame(); }
-      else if (!shouldRun) running = false;
-    });
-    visObserver.observe(canvas.parentElement);
-    document.addEventListener("visibilitychange", () => {
-      const onScreen = canvas.parentElement.getBoundingClientRect().bottom > 0;
-      const shouldRun = !document.hidden && onScreen;
-      if (shouldRun && !running) { running = true; frame(); }
-      else if (!shouldRun) running = false;
-    });
-
-    let canvasResizeTimer;
-    window.addEventListener("resize", () => {
-      clearTimeout(canvasResizeTimer);
-      canvasResizeTimer = setTimeout(build, 200);
-    }, { passive: true });
-
-    build();
-    frame();
-  }
+  /* ---------------- Hero WebGL scene lives in assets/js/hero3d.js ---------------- */
 
   /* ---------------- Tilt (work cards) ---------------- */
   if (finePointer && !reduceMotion) {
@@ -558,14 +499,22 @@
       });
       card.addEventListener("pointermove", (e) => {
         const r = card.getBoundingClientRect();
-        const rx = (0.5 - (e.clientY - r.top) / r.height) * 3.4;
-        const ry = ((e.clientX - r.left) / r.width - 0.5) * 3.4;
-        card.style.transform = `perspective(1100px) rotateX(${rx.toFixed(2)}deg) rotateY(${ry.toFixed(2)}deg)`;
+        const rx = (0.5 - (e.clientY - r.top) / r.height) * 4.2;
+        const ry = ((e.clientX - r.left) / r.width - 0.5) * 4.2;
+        // Pointer tilt writes its own vars so it stacks with the
+        // scroll-driven coverflow rotation instead of overwriting it.
+        card.style.setProperty("--mrx", `${rx.toFixed(2)}deg`);
+        card.style.setProperty("--mry", `${ry.toFixed(2)}deg`);
+        const gx = ((e.clientX - r.left) / r.width * 100).toFixed(1);
+        const gy = ((e.clientY - r.top) / r.height * 100).toFixed(1);
+        card.style.setProperty("--gx", `${gx}%`);
+        card.style.setProperty("--gy", `${gy}%`);
       });
       card.addEventListener("pointerleave", () => {
         card.classList.remove("is-tilting");
         card.classList.add("is-tilt-leaving");
-        card.style.transform = "";
+        card.style.setProperty("--mrx", "0deg");
+        card.style.setProperty("--mry", "0deg");
         setTimeout(() => card.classList.remove("is-tilt-leaving"), 720);
       });
     });

--- a/index.html
+++ b/index.html
@@ -3,14 +3,14 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>AlpovkApps — Product studio of Alperen Karavelioglu</title>
-  <meta name="description" content="AlpovkApps is the independent product studio of Alperen Karavelioglu — a senior software engineer who takes web, mobile and AI products from first commit to funded, shipped and acquired." />
+  <title>AlpovkApps — Software studio of Alperen Karavelioglu</title>
+  <meta name="description" content="AlpovkApps is the independent software studio of Alperen Karavelioglu — a senior software engineer who takes web, mobile and AI products from first commit to funded, shipped and acquired." />
   <meta name="author" content="Alperen Karavelioglu" />
   <meta name="theme-color" content="#0b0b0c" />
 
   <meta property="og:type" content="website" />
   <meta property="og:title" content="AlpovkApps — Software that gets funded, shipped and acquired" />
-  <meta property="og:description" content="The product studio of Alperen Karavelioglu. Web platforms, mobile apps and AI products — built from zero to launch." />
+  <meta property="og:description" content="The software studio of Alperen Karavelioglu. Web platforms, mobile apps and AI products — built from zero to launch." />
   <meta property="og:url" content="https://alpovka.github.io/" />
   <meta name="twitter:card" content="summary" />
 
@@ -22,6 +22,12 @@
   <link href="https://fonts.googleapis.com/css2?family=Inter+Tight:wght@400;500;600&family=Inter:wght@400;500;600&family=Instrument+Serif:ital@0;1&display=swap" rel="stylesheet" />
 
   <link rel="stylesheet" href="assets/css/style.css" />
+
+  <!-- Three.js for the WebGL hero (no build step) -->
+  <link rel="modulepreload" href="https://cdn.jsdelivr.net/npm/three@0.169.0/build/three.module.js" />
+  <script type="importmap">
+  { "imports": { "three": "https://cdn.jsdelivr.net/npm/three@0.169.0/build/three.module.js" } }
+  </script>
 </head>
 <body>
 
@@ -105,7 +111,7 @@
       <div class="container hero-inner" id="heroInner">
         <p class="hero-kicker caps anim-rise" style="--d:.05s">
           <span class="pulse" aria-hidden="true"></span>
-          AlpovkApps — Product studio of Alperen Karavelioglu
+          Software studio of Alperen Karavelioglu
         </p>
 
         <h1 class="hero-title" id="heroTitle">
@@ -144,15 +150,11 @@
       <svg class="hero-badge" viewBox="0 0 100 100" aria-hidden="true">
         <defs><path id="circ" d="M50,50 m-38,0 a38,38 0 1,1 76,0 a38,38 0 1,1 -76,0"/></defs>
         <text font-size="9.5" letter-spacing="2.6" fill="currentColor">
-          <textPath href="#circ">PRODUCT STUDIO — ALPOVKAPPS — EST. 2023 —</textPath>
+          <textPath href="#circ">SOFTWARE STUDIO — ALPOVKAPPS — EST. 2023 —</textPath>
         </text>
         <path class="badge-a" d="M50 38 L57 58 H43 Z"/>
       </svg>
 
-      <a class="scroll-cue" href="#stats" aria-label="Scroll down">
-        <span class="caps">Scroll</span>
-        <span class="scroll-cue-line"></span>
-      </a>
     </section>
 
     <!-- ░ Stats -->
@@ -588,5 +590,6 @@
   <div class="toast" id="toast" role="status" aria-live="polite"></div>
 
   <script src="assets/js/main.js" defer></script>
+  <script type="module" src="assets/js/hero3d.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
Adds a more advanced, interactive feel to the hero and work sections, plus fixes the mobile menu and refreshes some copy.

### Hero — cursor-reactive WebGL field
- Replaces the old 2D "dust" canvas with a **three.js** point-field: a faint monochrome dot grid at rest, where the cursor stirs a champagne **ripple-pool** that radiates a wave and brightens nearby points.
- Loaded via **importmap (no build step)** so the site stays a static page.
- Theme-aware (reads CSS color tokens, updates on theme toggle), pauses off-screen and when the tab is hidden, with a **reduced-motion** static frame and a graceful **no-WebGL** no-op.

### Work gallery — scroll-driven 3D
- Pinned horizontal gallery cards now swing in a 3D **coverflow** (rotate/recede/dim as they leave centre), composed with the existing **cursor tilt** and a cursor-tracked **sheen** via CSS variables so the two transforms don't clash.

### Mobile menu fix
- The open menu overlay no longer collapses into page content on scrolled sections. Root cause: the header's `transform` **and** `backdrop-filter` (`.is-scrolled`) each establish a containing block for the fixed full-screen overlay. Both are now neutralised while the menu is open.

### Copy
- Removed the hero scroll indicator.
- Renamed "Product studio" → "Software studio" and dropped "AlpovkApps —" from the hero kicker.

## Notes
- Three.js is pulled from a pinned CDN (`three@0.169.0`) via importmap.
- Stale Next.js leftovers (`.next/`, `next-env.d.ts`) are intentionally **not** included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)